### PR TITLE
Fix void pointer arithmetic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Once you have compiled the deep learning model that you want to try, the C++ cod
 ```
 ## make sure you are in the root directory of repo
 cd ./src/out/ICFP18evaluation/evaluationRNN/
-g++ -std=c++11 -O3 -march=native -Wno-pointer-arith Lantern.cpp -o Lantern
+g++ -std=c++11 -O3 -march=native Lantern.cpp -o Lantern
 ./Lantern result.txt
 ```
 

--- a/src/main/scala/lantern/dslapi.scala
+++ b/src/main/scala/lantern/dslapi.scala
@@ -495,7 +495,7 @@ abstract class DslDriverC[A: Manifest, B: Manifest] extends DslSnippet[A, B] wit
     (new java.io.File("/tmp/snippet")).delete
     import scala.sys.process._
     System.out.println("Compile C++ code")
-    (s"g++ -std=c++11 -O1 -Wno-pointer-arith /tmp/snippet.cpp -o /tmp/snippet": ProcessBuilder).lines.foreach(System.out.println _) //-std=c99
+    (s"g++ -std=c++11 -O1 /tmp/snippet.cpp -o /tmp/snippet": ProcessBuilder).lines.foreach(System.out.println _) //-std=c99
     System.out.println("Run C++ code")
     (s"/tmp/snippet $a": ProcessBuilder).lines.foreach(System.out.println _)
   }

--- a/src/main/scala/lantern/dslapi.scala
+++ b/src/main/scala/lantern/dslapi.scala
@@ -411,7 +411,9 @@ trait DslGenC extends CGenNumericOps
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        mallocAddr += bytes;
+        char* tmp = (char*) mallocAddr;
+        tmp += bytes;
+        mallocAddr = (void*) tmp;
         return res;
       }
 

--- a/src/main/scala/lantern/dslapi.scala
+++ b/src/main/scala/lantern/dslapi.scala
@@ -411,9 +411,7 @@ trait DslGenC extends CGenNumericOps
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        char* tmp = (char*) mallocAddr;
-        tmp += bytes;
-        mallocAddr = (void*) tmp;
+        mallocAddr = (void *)((char *)mallocAddr + bytes);
         return res;
       }
 

--- a/src/out/ICFP18evaluation/evaluationCNN/Lantern/Lantern.cpp
+++ b/src/out/ICFP18evaluation/evaluationCNN/Lantern/Lantern.cpp
@@ -46,7 +46,9 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        mallocAddr += bytes;
+        char* tmp = (char*) mallocAddr;
+        tmp += bytes;
+        mallocAddr = (void*) tmp;
         return res;
       }
 

--- a/src/out/ICFP18evaluation/evaluationCNN/Lantern/Lantern.cpp
+++ b/src/out/ICFP18evaluation/evaluationCNN/Lantern/Lantern.cpp
@@ -46,9 +46,7 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        char* tmp = (char*) mallocAddr;
-        tmp += bytes;
-        mallocAddr = (void*) tmp;
+        mallocAddr = (void *)((char *)mallocAddr + bytes);
         return res;
       }
 

--- a/src/out/ICFP18evaluation/evaluationLSTM/Lantern.cpp
+++ b/src/out/ICFP18evaluation/evaluationLSTM/Lantern.cpp
@@ -46,7 +46,9 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        mallocAddr += bytes;
+        char* tmp = (char*) mallocAddr;
+        tmp += bytes;
+        mallocAddr = (void*) tmp;
         return res;
       }
 

--- a/src/out/ICFP18evaluation/evaluationLSTM/Lantern.cpp
+++ b/src/out/ICFP18evaluation/evaluationLSTM/Lantern.cpp
@@ -46,9 +46,7 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        char* tmp = (char*) mallocAddr;
-        tmp += bytes;
-        mallocAddr = (void*) tmp;
+        mallocAddr = (void *)((char *)mallocAddr + bytes);
         return res;
       }
 

--- a/src/out/ICFP18evaluation/evaluationRNN/Lantern.cpp
+++ b/src/out/ICFP18evaluation/evaluationRNN/Lantern.cpp
@@ -46,7 +46,9 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        mallocAddr += bytes;
+        char* tmp = (char*) mallocAddr;
+        tmp += bytes;
+        mallocAddr = (void*) tmp;
         return res;
       }
 

--- a/src/out/ICFP18evaluation/evaluationRNN/Lantern.cpp
+++ b/src/out/ICFP18evaluation/evaluationRNN/Lantern.cpp
@@ -46,9 +46,7 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        char* tmp = (char*) mallocAddr;
-        tmp += bytes;
-        mallocAddr = (void*) tmp;
+        mallocAddr = (void *)((char *)mallocAddr + bytes);
         return res;
       }
 

--- a/src/out/ICFP18evaluation/evaluationTreeLSTM/Lantern/Lantern.cpp
+++ b/src/out/ICFP18evaluation/evaluationTreeLSTM/Lantern/Lantern.cpp
@@ -46,7 +46,9 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        mallocAddr += bytes;
+        char* tmp = (char*) mallocAddr;
+        tmp += bytes;
+        mallocAddr = (void*) tmp;
         return res;
       }
 

--- a/src/out/ICFP18evaluation/evaluationTreeLSTM/Lantern/Lantern.cpp
+++ b/src/out/ICFP18evaluation/evaluationTreeLSTM/Lantern/Lantern.cpp
@@ -46,9 +46,7 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        char* tmp = (char*) mallocAddr;
-        tmp += bytes;
-        mallocAddr = (void*) tmp;
+        mallocAddr = (void *)((char *)mallocAddr + bytes);
         return res;
       }
 

--- a/src/out/untested/sentiment_lstm.cpp
+++ b/src/out/untested/sentiment_lstm.cpp
@@ -46,7 +46,9 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        mallocAddr += bytes;
+        char* tmp = (char*) mallocAddr;
+        tmp += bytes;
+        mallocAddr = (void*) tmp;
         return res;
       }
 

--- a/src/out/untested/sentiment_lstm.cpp
+++ b/src/out/untested/sentiment_lstm.cpp
@@ -46,9 +46,7 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        char* tmp = (char*) mallocAddr;
-        tmp += bytes;
-        mallocAddr = (void*) tmp;
+        mallocAddr = (void *)((char *)mallocAddr + bytes);
         return res;
       }
 

--- a/src/out/untested/sentiment_tree_rnn.cpp
+++ b/src/out/untested/sentiment_tree_rnn.cpp
@@ -46,7 +46,9 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        mallocAddr += bytes;
+        char* tmp = (char*) mallocAddr;
+        tmp += bytes;
+        mallocAddr = (void*) tmp;
         return res;
       }
 

--- a/src/out/untested/sentiment_tree_rnn.cpp
+++ b/src/out/untested/sentiment_tree_rnn.cpp
@@ -46,9 +46,7 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        char* tmp = (char*) mallocAddr;
-        tmp += bytes;
-        mallocAddr = (void*) tmp;
+        mallocAddr = (void *)((char *)mallocAddr + bytes);
         return res;
       }
 

--- a/src/out/untested/vanilla_rnn_list.cpp
+++ b/src/out/untested/vanilla_rnn_list.cpp
@@ -46,7 +46,9 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        mallocAddr += bytes;
+        char* tmp = (char*) mallocAddr;
+        tmp += bytes;
+        mallocAddr = (void*) tmp;
         return res;
       }
 

--- a/src/out/untested/vanilla_rnn_list.cpp
+++ b/src/out/untested/vanilla_rnn_list.cpp
@@ -46,9 +46,7 @@
       void *waterMark  = mallocBase;
       void* myMalloc(size_t bytes) {
         void* res = mallocAddr;
-        char* tmp = (char*) mallocAddr;
-        tmp += bytes;
-        mallocAddr = (void*) tmp;
+        mallocAddr = (void *)((char *)mallocAddr + bytes);
         return res;
       }
 

--- a/src/test/scala/lantern/test_ad_lms_vector.scala
+++ b/src/test/scala/lantern/test_ad_lms_vector.scala
@@ -46,7 +46,7 @@ class AdLMSVectorTest extends FunSuite {
 
   test("array1") {
 
-    val array1 = new DslDriverC[String, Unit]  with TensorExp {
+    val array1 = new DslDriverC[String, Unit] with TensorExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {


### PR DESCRIPTION
Currently, void pointer arithmetic produces a `clang` compilation error:
```
/tmp/snippet.cpp:49:20: error: arithmetic on a pointer to void
        mallocAddr += bytes;
        ~~~~~~~~~~ ^
```

Fixed by casting void pointer to char pointer before performing arithmetic.