### PR TITLE
Separate backend setup/cleanup from codegen template.

### DIFF
--- a/src/main/scala/lantern/ad_lms_vector.scala
+++ b/src/main/scala/lantern/ad_lms_vector.scala
@@ -296,8 +296,8 @@ trait TensorExp extends Dsl with Diff {
     * cuBLAS tensor operation backend. WIP.
     */
   class BackendCublas extends Backend {
-    override def setup(): Unit = unchecked[Unit]("cublasHandle_t handle;\nCUBLAS_CALL(cublasCreate(&handle));")
-    override def cleanup(): Unit = unchecked[Unit]("CUBLAS_CALL(cublasDestroy(handle));")
+    override def setup(): Unit = generateRawCode("cublasHandle_t handle;\nCUBLAS_CALL(cublasCreate(&handle));")
+    override def cleanup(): Unit = generateRawCode("CUBLAS_CALL(cublasDestroy(handle));")
 
     // Reference:
     // https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot
@@ -354,8 +354,8 @@ trait TensorExp extends Dsl with Diff {
     * cuDNN tensor operation backend. WIP.
     */
   class BackendCudnn extends Backend {
-    override def setup(): Unit = unchecked[Unit]("cudnnHandle_t handle;\nCUDNN_CALL(cudnnCreate(&handle));")
-    override def cleanup(): Unit = unchecked[Unit]("CUDNN_CALL(cudnnDestroy(handle));")
+    override def setup(): Unit = generateRawCode("cudnnHandle_t handle;\nCUDNN_CALL(cudnnCreate(&handle));")
+    override def cleanup(): Unit = generateRawCode("CUDNN_CALL(cudnnDestroy(handle));")
 
     override def vectorVectorDot(x: Tensor, y: Tensor): Tensor = ???
     override def matrixVectorDot(x: Tensor, y: Tensor): Tensor = ???

--- a/src/test/scala/lantern/LSTM.scala
+++ b/src/test/scala/lantern/LSTM.scala
@@ -23,7 +23,7 @@ class LSTMTest extends FunSuite {
   val root_dir = "src/out/ICFP18evaluation/"
   val file_dir = "evaluationLSTM/Lantern.cpp"
 
-  val min_char_lstm = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+  val min_char_lstm = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
     class Scanner(name: Rep[String]) {
       val fd = open(name)

--- a/src/test/scala/lantern/LanternFunSuite.scala
+++ b/src/test/scala/lantern/LanternFunSuite.scala
@@ -3,7 +3,7 @@ package lantern
 import org.scalatest.FunSuite
 
 class LanternFunSuite extends FunSuite {
-  def runTest(snippet: DslDriverBase[String, Unit]) {
-    snippet.eval("dummy")
+  def runTest(driver: LanternDriver[String, Unit]) {
+    driver.eval("dummy")
   }
 }

--- a/src/test/scala/lantern/mnistCNN.scala
+++ b/src/test/scala/lantern/mnistCNN.scala
@@ -22,7 +22,7 @@ class MnistCNN extends FunSuite {
   val root_dir = "src/out/ICFP18evaluation/"
   val file_dir = "evaluationCNN/Lantern/Lantern.cpp"
 
-  val mnist  = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+  val mnist  = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
     // From the MNIST pytorch example
     val mean = 0.1307f

--- a/src/test/scala/lantern/sentimentLSTM.scala
+++ b/src/test/scala/lantern/sentimentLSTM.scala
@@ -21,7 +21,7 @@ class SentimentLSTM extends FunSuite {
 
   val file_dir = "/tmp/sentiment_lstm.cpp"
 
-  val senti_seq_lstm = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+  val senti_seq_lstm = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
     @virtualize
     def snippet(a: Rep[String]): Rep[Unit] = {

--- a/src/test/scala/lantern/sentimentRNN.scala
+++ b/src/test/scala/lantern/sentimentRNN.scala
@@ -21,7 +21,7 @@ class SentimentTreeRNN extends FunSuite {
 
   val file_dir = "/tmp/sentiment_tree_rnn.cpp"
 
-	val sentimental_rnn = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+	val sentimental_rnn = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
     @virtualize
     def snippet(a: Rep[String]): Rep[Unit] = {

--- a/src/test/scala/lantern/sentimentTreeLSTM.scala
+++ b/src/test/scala/lantern/sentimentTreeLSTM.scala
@@ -22,7 +22,7 @@ class SentimentTreeLSTM extends FunSuite {
   val root_dir = "src/out/ICFP18evaluation/"
   val file_dir = "evaluationTreeLSTM/Lantern/Lantern.cpp"
 
-  val sentimental_lstm = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+  val sentimental_lstm = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
     @virtualize
     def snippet(a: Rep[String]): Rep[Unit] = {

--- a/src/test/scala/lantern/test_ad_lms_vector.scala
+++ b/src/test/scala/lantern/test_ad_lms_vector.scala
@@ -19,7 +19,7 @@ import java.io.File
 class AdLMSVectorTest extends LanternFunSuite {
 
   test("array0") {
-    val array0 = new DslDriverC[String, Unit] with TensorExp {
+    val array0 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -39,7 +39,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("vector-vector-dot") {
-    val vvdot = new DslDriverC[String, Unit] with TensorExp {
+    val vvdot = new LanternDriverC[String, Unit] {
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -53,7 +53,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("matrix-vector-dot") {
-    val mvdot = new DslDriverC[String, Unit] with TensorExp {
+    val mvdot = new LanternDriverC[String, Unit] {
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
         val m = Tensor.fromData(NSeq(2, 4), 1, 2, 3, 4, 5, 6, 7, 8)
@@ -66,7 +66,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("matrix-matrix-dot") {
-    val mmdot = new DslDriverC[String, Unit] with TensorExp {
+    val mmdot = new LanternDriverC[String, Unit] {
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
         // Note: it's better to test with non-square matrices.
@@ -80,7 +80,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array2") {
-    val array2 = new DslDriverC[String, Unit] with TensorExp {
+    val array2 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -104,7 +104,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array2_1"){
-    val array2_1 = new DslDriverC[String, Unit] with TensorExp {
+    val array2_1 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -131,7 +131,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array2_2") {
-    val array2_2 = new DslDriverC[String, Unit] with TensorExp {
+    val array2_2 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -161,7 +161,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("testTrans") {
-    val testTrans = new DslDriverC[String, Unit] with TensorExp {
+    val testTrans = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -175,7 +175,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array2_3") {
-    val array2_3 = new DslDriverC[String, Unit] with TensorExp {
+    val array2_3 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -305,7 +305,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array2_4"){
-    val array2_4 = new DslDriverC[String, Unit] with TensorExp {
+    val array2_4 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet (a: Rep[String]): Rep[Unit] = {
@@ -331,7 +331,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array2_5") {
-    val array2_5 = new DslDriverC[String, Unit] with TensorExp {
+    val array2_5 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet (a: Rep[String]): Rep[Unit] = {
@@ -358,7 +358,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array3") {
-    val array3 = new DslDriverC[String, Unit] with TensorExp {
+    val array3 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -381,7 +381,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array4") {
-    val array4 = new DslDriverC[String, Unit] with TensorExp {
+    val array4 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -404,7 +404,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array4_1") {
-    val array4_1 = new DslDriverC[String, Unit] with TensorExp {
+    val array4_1 = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -436,7 +436,7 @@ class AdLMSVectorTest extends LanternFunSuite {
 
   test("array4_2") {
     // test using array data by closure
-    val array4_2 = new DslDriverC[String, Unit] with TensorExp {
+    val array4_2 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
 
@@ -480,7 +480,7 @@ class AdLMSVectorTest extends LanternFunSuite {
 
 
   test("array4_4") {
-    val array4_4 = new DslDriverC[String, Unit] with TensorExp {
+    val array4_4 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -521,7 +521,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array5") {
-    val array5 = new DslDriverC[String, Unit] with TensorExp {
+    val array5 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -537,7 +537,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array6") {
-    val array6 = new DslDriverC[String, Unit] with TensorExp {
+    val array6 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -552,7 +552,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array7") {
-    val array7 = new DslDriverC[String, Unit] with TensorExp {
+    val array7 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -569,7 +569,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array7_1") {
-    val array7_1 = new DslDriverC[String, Unit] with TensorExp {
+    val array7_1 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -587,7 +587,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array8"){
-    val array8 = new DslDriverC[String, Unit] with TensorExp {
+    val array8 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -604,7 +604,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array9") {
-    val array9 = new DslDriverC[String, Unit] with TensorExp {
+    val array9 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -620,7 +620,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array10") {
-    val array10 = new DslDriverC[String, Unit] with TensorExp {
+    val array10 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -652,7 +652,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array11") {
-    val array11 = new DslDriverC[String, Unit] with TensorExp {
+    val array11 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -703,7 +703,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("array11_1") {
-    val array11_1 = new DslDriverC[String, Unit] with TensorExp {
+    val array11_1 = new LanternDriverC[String, Unit] {
 
       def snippet(a: Rep[String]): Rep[Unit] = {
         val length = 2
@@ -766,7 +766,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_test1") {
-    val cnn_test1 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_test1 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -789,7 +789,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_test2") {
-    val cnn_test2 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_test2 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -814,7 +814,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_test3") {
-    val cnn_test3 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_test3 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -838,7 +838,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_back_test1") {
-    val cnn_back_test1 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_back_test1 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -880,7 +880,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_back_test2") {
-    val cnn_back_test2 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_back_test2 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -922,7 +922,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_back_test3") {
-    val cnn_back_test3 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_back_test3 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -963,7 +963,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_test4") {
-    val cnn_test4 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_test4 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -989,7 +989,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_back_test4") {
-    val cnn_back_test4 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_back_test4 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1031,7 +1031,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_test5") {
-    val cnn_test5 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_test5 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1057,7 +1057,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("cnn_back_test5") {
-    val cnn_back_test5 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val cnn_back_test5 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1098,7 +1098,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("maxpool_test1") {
-    val maxpool_test1 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val maxpool_test1 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1123,7 +1123,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("maxpool_back_test1") {
-    val maxpool_back_test1 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val maxpool_back_test1 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1156,7 +1156,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("dropout_test1") {
-    val dropout_test1 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val dropout_test1 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1182,7 +1182,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("dropout_back_test1") {
-    val dropout_back_test1 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val dropout_back_test1 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1208,7 +1208,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("dropout_back_test2") {
-    val dropout_back_test2 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val dropout_back_test2 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1234,7 +1234,7 @@ class AdLMSVectorTest extends LanternFunSuite {
   }
 
   test("test_cnn_full1") {
-    val test_cnn_full1 = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+    val test_cnn_full1 = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
       // FIXME: add proper check for result. see adworkplace/pytorch/cnn_test.py
       def snippet(a: Rep[String]): Rep[Unit] = {
@@ -1315,7 +1315,7 @@ class AdLMSVectorTest extends LanternFunSuite {
 
   test("op_conv") {
 
-    val deb = new DslDriverC[String, Unit] with TensorExp {
+    val deb = new LanternDriverC[String, Unit] {
       import scala.collection.Seq;
 
       @virtualize
@@ -1343,7 +1343,7 @@ class AdLMSVectorTest extends LanternFunSuite {
 
   test("op_conv_pad") {
 
-    val deb = new DslDriverC[String, Unit] with TensorExp {
+    val deb = new LanternDriverC[String, Unit] {
       import scala.collection.Seq;
 
       @virtualize
@@ -1370,7 +1370,7 @@ class AdLMSVectorTest extends LanternFunSuite {
 
   test("backprop_op_conv") {
 
-    val deb = new DslDriverC[String, Unit] with TensorExp {
+    val deb = new LanternDriverC[String, Unit] {
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
         val input = TensorR(Tensor.ones(1,1,4,4))
@@ -1405,7 +1405,7 @@ class AdLMSVectorTest extends LanternFunSuite {
 
   test("backprop_op_conv_pad") {
 
-    val deb = new DslDriverC[String, Unit] with TensorExp {
+    val deb = new LanternDriverC[String, Unit] {
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
         val input = TensorR(Tensor.ones(1,1,4,4))

--- a/src/test/scala/lantern/test_broadcast.scala
+++ b/src/test/scala/lantern/test_broadcast.scala
@@ -19,7 +19,7 @@ import java.io.File;
 
 class BroadCastingTest extends FunSuite {
   test("broadcasting") {
-    val test1 = new DslDriverC[String, Unit] with TensorExp {
+    val test1 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]) = {}
       def test() = {
         def dimfy(x: Option[(NSeq[Int], NSeq[Int], NSeq[Int])]) = x match {
@@ -43,7 +43,7 @@ class BroadCastingTest extends FunSuite {
   }
 
   test("add_broadcast1") {
-    val test1 = new DslDriverC[String, Unit] with TensorExp {
+    val test1 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]): Rep[Unit] = {
         val tensor1 = Tensor(Array(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f), 2, 3)
         val tensor2 = Tensor(Array[Float](6,5,4,3,2,1), 2, 3)
@@ -63,7 +63,7 @@ class BroadCastingTest extends FunSuite {
   }
 
   test("add_broadcast2") {
-    val test2 = new DslDriverC[String, Unit] with TensorExp {
+    val test2 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]): Rep[Unit] = {
         val tensor1 = Tensor(Array[Float](1,2,3,4,5,6), 2, 3)
         val tensor2 = Tensor(Array[Float](1,2), 2, 1)
@@ -83,7 +83,7 @@ class BroadCastingTest extends FunSuite {
   }
 
   test("add_broadcast3") {
-    val test3 = new DslDriverC[String, Unit] with TensorExp {
+    val test3 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]): Rep[Unit] = {
         val tensor1 = Tensor(Array[Float](1,2,3,4,5,6), 2, 3)
         val tensor2 = Tensor(Array[Float](3,4,5), 1, 3)
@@ -103,7 +103,7 @@ class BroadCastingTest extends FunSuite {
   }
 
   test("add_broadcast4") {
-    val test4 = new DslDriverC[String, Unit] with TensorExp {
+    val test4 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]): Rep[Unit] = {
         val tensor1 = Tensor(Array[Float](1,2,3,4,5,6,7,8), 2,2,2)
         val tensor2 = Tensor(Array[Float](1,2), 2)
@@ -123,7 +123,7 @@ class BroadCastingTest extends FunSuite {
   }
 
   test("add_broadcast5") {
-    val test5 = new DslDriverC[String, Unit] with TensorExp {
+    val test5 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]): Rep[Unit] = {
         val tensor1 = Tensor(Array[Float](1,2,3,4,5,6,7,8), 2, 2, 2)
         val tensor2 = Tensor(Array[Float](1,2,3,4), 2, 1, 2)
@@ -146,7 +146,7 @@ class BroadCastingTest extends FunSuite {
   }
 
   test("minus_broadcast5") {
-    val test5 = new DslDriverC[String, Unit] with TensorExp {
+    val test5 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]): Rep[Unit] = {
         val tensor1 = Tensor(Array[Float](1,2,3,4,5,6,7,8), 2, 2, 2)
         val tensor2 = Tensor(Array[Float](1,2,3,4), 2, 1, 2)
@@ -165,7 +165,7 @@ class BroadCastingTest extends FunSuite {
   }
 
   test("mult_broadcast5") {
-    val test5 = new DslDriverC[String, Unit] with TensorExp {
+    val test5 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]): Rep[Unit] = {
         val tensor1 = Tensor(Array[Float](1,2,3,4,5,6,7,8), 2, 2, 2)
         val tensor2 = Tensor(Array[Float](1,2,3,4), 2, 1, 2)
@@ -185,7 +185,7 @@ class BroadCastingTest extends FunSuite {
   }
 
   test("div_broadcast5") {
-    val test5 = new DslDriverC[String, Unit] with TensorExp {
+    val test5 = new LanternDriverC[String, Unit] {
       def snippet(a: Rep[String]): Rep[Unit] = {
         val tensor1 = Tensor(Array[Float](1,2,3,4,5,6,7,8), 2, 2, 2)
         val tensor2 = Tensor(Array[Float](1,2,2,4), 2, 1, 2)

--- a/src/test/scala/lantern/test_cublas.scala
+++ b/src/test/scala/lantern/test_cublas.scala
@@ -18,7 +18,7 @@ class CublasTest extends FunSuite {
   def isGPUAvailable = false
 
   testGPU("vector-vector-dot") {
-    val vvdot = new DslDriverCublas[String, Unit] with TensorExp {
+    val vvdot = new LanternDriverCublas[String, Unit] {
       backend = new BackendCublas
 
       @virtualize
@@ -34,7 +34,7 @@ class CublasTest extends FunSuite {
   }
 
   testGPU("matrix-vector-dot") {
-    val mvdot = new DslDriverCublas[String, Unit] with TensorExp {
+    val mvdot = new LanternDriverCublas[String, Unit] {
       backend = new BackendCublas
 
       @virtualize
@@ -49,7 +49,7 @@ class CublasTest extends FunSuite {
   }
 
   testGPU("matrix-matrix-dot") {
-    val mmdot = new DslDriverCublas[String, Unit] with TensorExp {
+    val mmdot = new LanternDriverCublas[String, Unit] {
       backend = new BackendCublas
 
       @virtualize

--- a/src/test/scala/lantern/test_onnx.scala
+++ b/src/test/scala/lantern/test_onnx.scala
@@ -169,7 +169,7 @@ class ONNXTest extends FunSuite {
 
   test("build_from_onnx") {
 
-    val squeezenet = new DslDriverC[String, Unit] with TensorExp {
+    val squeezenet = new LanternDriverC[String, Unit] {
 
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {

--- a/src/test/scala/lantern/vanillaRNN.scala
+++ b/src/test/scala/lantern/vanillaRNN.scala
@@ -22,7 +22,7 @@ class VanillaRNN extends FunSuite {
   val root_dir = "src/out/ICFP18evaluation/"
   val file_dir = "evaluationRNN/Lantern.cpp"
 
-  val min_char_rnn = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+  val min_char_rnn = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
     class Scanner(name: Rep[String]) {
       val fd = open(name)

--- a/src/test/scala/lantern/vanillaRNNList.scala
+++ b/src/test/scala/lantern/vanillaRNNList.scala
@@ -21,7 +21,7 @@ class VanillaRNNList extends FunSuite {
 
   val file_dir = "/tmp/vanilla_rnn_list.cpp/"
 
-  val min_char_list = new DslDriverC[String, Unit] with TensorExp with ScannerLowerExp {
+  val min_char_list = new LanternDriverC[String, Unit] with ScannerLowerExp {
 
     class Scanner(name: Rep[String]) {
       val fd = open(name)


### PR DESCRIPTION
- Move `cublasHandle_t` management from codegen template to `Backend` trait.
- Create `LanternDriver` trait defining a `wrapper` function around
  `snippet` that performs backend setup/cleanup.
- Use subclasses of `LanternDriver` in tests.

Note: if one manually implements `DslDriverC extends TensorExp`, they
are now responsible for invoking `backend.setup()` and `backend.cleanup()`
within the snippet.

Using subclasses of `LanternDriver` directly (e.g. `LanternDriverC`) is
highly encouraged.

Addresses [feedback](https://github.com/feiwang3311/Lantern/pull/18#discussion_r223192324)  by @TiarkRompf.