### PR TITLE
Implement backend-defined data allocation and transfer ops.

### DIFF
--- a/src/main/scala/lantern/ad_lms.scala
+++ b/src/main/scala/lantern/ad_lms.scala
@@ -13,7 +13,7 @@ trait Diff {
   def RST(a: =>Unit @diff) = continuations.reset { a; () }
 }
 
-trait DiffApi extends Dsl with Diff {
+trait DiffApi extends DslOps with Diff {
 
   type RDouble = Rep[Double]
 

--- a/src/main/scala/lantern/future.scala
+++ b/src/main/scala/lantern/future.scala
@@ -7,7 +7,7 @@ import org.scala_lang.virtualized.SourceContext
 
 import scala.virtualization.lms._
 
-trait TestExp extends Dsl {
+trait TestExp extends DslOps {
   type Size = Int
 
   object Size {

--- a/src/main/scala/lantern/nnModule.scala
+++ b/src/main/scala/lantern/nnModule.scala
@@ -16,7 +16,7 @@ import scala.math._
 import scala.reflect.runtime.universe._
 import java.lang.reflect.Field
 
-trait NNModule extends TensorExp {
+trait NNModule extends TensorDsl {
 
   abstract class Module {
     val name: String

--- a/src/main/scala/lantern/onnxLib.scala
+++ b/src/main/scala/lantern/onnxLib.scala
@@ -31,7 +31,7 @@ import java.io._
 import scala.annotation.tailrec
 import scala.util.{Try, Success, Failure}
 
-trait ONNXLib extends TensorExp {
+trait ONNXLib extends TensorDsl {
 
   object ParseHelper {
 

--- a/src/main/scala/lantern/scanner.scala
+++ b/src/main/scala/lantern/scanner.scala
@@ -5,7 +5,7 @@ import org.scala_lang.virtualized.SourceContext
 
 import scala.virtualization.lms.common._
 
-trait ScannerLowerBase extends Base with UncheckedOps { this: Dsl =>
+trait ScannerLowerBase extends Base with UncheckedOps { this: DslOps =>
   def open(name: Rep[String]): Rep[Int]
   def close(fd: Rep[Int]): Rep[Unit]
   def filelen(fd: Rep[Int]): Rep[Int]

--- a/src/test/scala/lantern/TestCublas.scala
+++ b/src/test/scala/lantern/TestCublas.scala
@@ -46,5 +46,4 @@ class TestCublas extends LanternFunSuite {
     }
     runTest(mmdot)
   }
-
 }


### PR DESCRIPTION
- Use `backend.mallocArray` to allocate tensor data.
- Remove `TensorNew`, `TensorApply`, `TensorUpdate` expressions.
- Rename various traits/classes to be more accurate.
  - `Dsl` -> `DslOps` (the trait does define ops)
  - `TensorExp` -> `TensorDsl` (the trait doesn't define expressions)
  - `BackendNative` -> `BackendCPU`
- Make backend class singletons.
- Implement `toCPU` and `toGPU` transfer ops.

TODO:
- Make more tensor ops be backend-defined (e.g. addition).
- Add some sort of backend-defined `free` operation.
- Consider merging `DslDriverXX` and `LanternDriverXX` for simplicity.