### PR TITLE
Implement GPU elementwise binary op broadcasting.

### DIFF
--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -2817,38 +2817,43 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
       Tensor(res, m, n)
     }
 
-    def launchBinaryKernel(n: Int, x: Tensor, y: Tensor, res: Rep[Array[Float]])
-                          (op: (String, String) => String): Unit = {
+    def launchBinaryKernel(x: Tensor, y: Tensor)(op: (String, String) => String): Tensor = {
       // TODO: Generalize to `launchKernel` function that's usable for unary ops, etc.
-      // TODO: Implement broadcasting.
       // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/Loops.cuh#L196
-      generateRawComment("SHAPES HERE")
+
+      // Compute broadcasting strides.
+      // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/TensorIterator.cpp#L396
+      // TODO: Generalize for different-ranked tensors. Currently, broadcasting works only for same-rank tensors.
+      def computeStrides(shape: Dimensions): Seq[Int] = {
+        shape.strides.zipWithIndex.map { case (s, i) =>
+          if (shape(i) == 1) 0 else s
+        }
+      }
 
       Tensor.dimBroadcast(x.shape, y.shape) match {
         case None => throw new IllegalArgumentException(s"Shapes cannot be broadcasted: ${x.shape.seq}, ${y.shape.seq}")
         case Some((xShape, yShape, resShape)) =>
-          System.out.println("Shapes", xShape, yShape, resShape)
-          System.out.println("Strides", xShape.strides, yShape.strides, resShape.strides)
           val xdims = Array(xShape.map(unit(_)): _*)
           val ydims = Array(yShape.map(unit(_)): _*)
           val rdims = Array(resShape.map(unit(_)): _*)
           val strides = NewArray[Array[Int]](3)
-          strides(0) = Array(xShape.strides.map(unit(_)): _*)
-          strides(1) = Array(yShape.strides.map(unit(_)): _*)
-          strides(2) = Array(resShape.strides.map(unit(_)): _*)
+          strides(0) = Array(computeStrides(resShape).map(unit(_)): _*)
+          strides(1) = Array(computeStrides(xShape).map(unit(_)): _*)
+          strides(2) = Array(computeStrides(yShape).map(unit(_)): _*)
 
+          val res = mallocArray[Float](resShape.nbElem)
           unchecked[Unit](
             "{\n" +
-            "OffsetCalculator<3> calc(", xShape.length, ",", rdims, ",", strides, "); \n" +
-            "launch_kernel<128, 4>(", n, ", [=]__device__(int idx) {\n" +
+            "OffsetCalculator<3> calc(", resShape.length, ",", rdims, ",", strides, "); \n" +
+            "launch_kernel<128, 4>(", resShape.nbElem, ", [=]__device__(int idx) {\n" +
             "  auto offsets = calc.get(idx);\n" +
-            // "  auto offsets = OffsetCalculator<3>(", xShape.length, ",", rdims, ",", strides, ").get(idx);\n" +
             "  float* out = (float*)&", res, "[offsets[0]];\n" +
             "  float* in1 = (float*)&", x.data, "[offsets[1]];\n" +
             "  float* in2 = (float*)&", y.data, "[offsets[2]];\n" +
             s"  *out = ${op("(*in1)", "(*in2)")};\n" +
             "});\n" +
             "}")
+          Tensor(res, resShape: _*)
       }
     }
 
@@ -2856,9 +2861,7 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
     override def +(x: Tensor, y: Rep[Float]): Tensor = ???
 
     override def +(x: Tensor, y: Tensor): Tensor = {
-      val res = mallocArray[Float](x.scalarCount)
-      launchBinaryKernel(x.scalarCount, x, y, res) { (a, b) => a + " + " + b }
-      Tensor(res, x.shape: _*)
+      launchBinaryKernel(x, y) { (a, b) => a + " + " + b }
     }
 
     override def +=(x: Tensor, y: Rep[Float]): Unit = ???
@@ -2866,9 +2869,7 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
 
     override def -(x: Tensor, y: Rep[Float]): Tensor = ???
     override def -(x: Tensor, y: Tensor): Tensor = {
-      val res = mallocArray[Float](x.scalarCount)
-      launchBinaryKernel(x.scalarCount, x, y, res) { (a, b) => a + " - " + b }
-      Tensor(res, x.shape: _*)
+      launchBinaryKernel(x, y) { (a, b) => a + " - " + b }
     }
 
     override def -=(x: Tensor, y: Rep[Float]): Unit = ???
@@ -2876,9 +2877,7 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
 
     override def *(x: Tensor, y: Rep[Float]): Tensor = ???
     override def *(x: Tensor, y: Tensor): Tensor = {
-      val res = mallocArray[Float](x.scalarCount)
-      launchBinaryKernel(x.scalarCount, x, y, res) { (a, b) => a + " * " + b }
-      Tensor(res, x.shape: _*)
+      launchBinaryKernel(x, y) { (a, b) => a + " * " + b }
     }
 
     override def *=(x: Tensor, y: Rep[Float]): Unit = ???
@@ -2886,9 +2885,7 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
 
     override def /(x: Tensor, y: Rep[Float]): Tensor = ???
     override def /(x: Tensor, y: Tensor): Tensor = {
-      val res = mallocArray[Float](x.scalarCount)
-      launchBinaryKernel(x.scalarCount, x, y, res) { (a, b) => a + " / " + b }
-      Tensor(res, x.shape: _*)
+      launchBinaryKernel(x, y) { (a, b) => a + " / " + b }
     }
 
     override def /=(x: Tensor, y: Rep[Float]): Unit = ???

--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -1580,7 +1580,6 @@ trait TensorDsl extends DslOps with Diff {
   }
 
   object Tensor {
-
     def apply(data: Rep[Array[Float]], dims: Int*) = new Tensor(data, dims)
 
     def dimCompatible(a: Tensor, b: Tensor) = {
@@ -1600,9 +1599,9 @@ trait TensorDsl extends DslOps with Diff {
       if (res == List(-1)) None
       else {
         // add dimensions of 1 to tensors with smaller rank
-        if (a.size > b.size) Some((new Dimensions(a), new Dimensions(Seq.fill(a.size - b.size)(1) ++ b), new Dimensions(res.toSeq)))
-        else if (a.size < b.size) Some((new Dimensions(Seq.fill(b.size - a.size)(1) ++ a), new Dimensions(b), new Dimensions(res.toSeq)))
-        else Some((new Dimensions(a), new Dimensions(b), new Dimensions(res.toSeq)))
+        if (a.size > b.size) Some((Dimensions(a), Dimensions(Seq.fill(a.size - b.size)(1) ++ b), Dimensions(res)))
+        else if (a.size < b.size) Some((Dimensions(Seq.fill(b.size - a.size)(1) ++ a), Dimensions(b), Dimensions(res)))
+        else Some((Dimensions(a), Dimensions(b), Dimensions(res)))
       }
     }
 
@@ -2823,13 +2822,34 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
       // TODO: Generalize to `launchKernel` function that's usable for unary ops, etc.
       // TODO: Implement broadcasting.
       // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/Loops.cuh#L196
-      unchecked[Unit](
-        "launch_kernel<128, 4>(", n, ", [=]__device__(int idx) {\n" +
-        "  float* out = (float*)&", res, "[idx];\n" +
-        "  float* in1 = (float*)&", x.data, "[idx];\n" +
-        "  float* in2 = (float*)&", y.data, "[idx];\n" +
-        s"  *out = ${op("(*in1)", "(*in2)")};\n" +
-        "});")
+      generateRawComment("SHAPES HERE")
+
+      Tensor.dimBroadcast(x.shape, y.shape) match {
+        case None => throw new IllegalArgumentException(s"Shapes cannot be broadcasted: ${x.shape.seq}, ${y.shape.seq}")
+        case Some((xShape, yShape, resShape)) =>
+          System.out.println("Shapes", xShape, yShape, resShape)
+          System.out.println("Strides", xShape.strides, yShape.strides, resShape.strides)
+          val xdims = Array(xShape.map(unit(_)): _*)
+          val ydims = Array(yShape.map(unit(_)): _*)
+          val rdims = Array(resShape.map(unit(_)): _*)
+          val strides = NewArray[Array[Int]](3)
+          strides(0) = Array(xShape.strides.map(unit(_)): _*)
+          strides(1) = Array(yShape.strides.map(unit(_)): _*)
+          strides(2) = Array(resShape.strides.map(unit(_)): _*)
+
+          unchecked[Unit](
+            "{\n" +
+            "OffsetCalculator<3> calc(", xShape.length, ",", rdims, ",", strides, "); \n" +
+            "launch_kernel<128, 4>(", n, ", [=]__device__(int idx) {\n" +
+            "  auto offsets = calc.get(idx);\n" +
+            // "  auto offsets = OffsetCalculator<3>(", xShape.length, ",", rdims, ",", strides, ").get(idx);\n" +
+            "  float* out = (float*)&", res, "[offsets[0]];\n" +
+            "  float* in1 = (float*)&", x.data, "[offsets[1]];\n" +
+            "  float* in2 = (float*)&", y.data, "[offsets[2]];\n" +
+            s"  *out = ${op("(*in1)", "(*in2)")};\n" +
+            "});\n" +
+            "}")
+      }
     }
 
     // TODO: Implement elementwise binary ops.

--- a/src/test/scala/lantern/TestCublas.scala
+++ b/src/test/scala/lantern/TestCublas.scala
@@ -100,4 +100,24 @@ class TestCublas extends LanternFunSuite {
     }
     runTest(binops)
   }
+
+  // TODO: Implement broadcasting.
+  testGPU("binary-ops-broadcast2") {
+    val binops = new LanternDriverCublas[String, Unit] {
+      override val fileName = "lantern-gpu-binops-broadcast2"
+
+      @virtualize
+      def snippet(x: Rep[String]): Rep[Unit] = {
+        val x = Tensor.fromData(Seq(2, 3, 2), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+        val y = Tensor.fromData(Seq(2, 1, 1), 4, 5)
+        val result = (x + y).toCPU()
+
+        backend = BackendCPU()
+        val expected = Tensor.fromData(Seq(2, 3, 2), 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16)
+        result.print()
+        Tensor.assertEqual(result, expected)
+      }
+    }
+    runTest(binops)
+  }
 }

--- a/src/test/scala/lantern/TestCublas.scala
+++ b/src/test/scala/lantern/TestCublas.scala
@@ -81,30 +81,9 @@ class TestCublas extends LanternFunSuite {
     runTest(binops)
   }
 
-  // TODO: Implement broadcasting.
-  testGPU("binary-ops-broadcast") {
+  testGPU("binary-ops-broadcast1") {
     val binops = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-binops-broadcast"
-
-      @virtualize
-      def snippet(x: Rep[String]): Rep[Unit] = {
-        val x = Tensor.fromData(Seq(2, 2), 1, 2, 3, 4)
-        val y = Tensor.fromData(Seq(2, 1), 4, 5)
-        val result = (x + y).toCPU()
-
-        backend = BackendCPU()
-        val expected = Tensor.fromData(Seq(2, 2), 5, 7, 7, 9)
-        result.print()
-        Tensor.assertEqual(result, expected)
-      }
-    }
-    runTest(binops)
-  }
-
-  // TODO: Implement broadcasting.
-  testGPU("binary-ops-broadcast2") {
-    val binops = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-binops-broadcast2"
+      override val fileName = "lantern-gpu-binops-broadcast1"
 
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
@@ -114,6 +93,31 @@ class TestCublas extends LanternFunSuite {
 
         backend = BackendCPU()
         val expected = Tensor.fromData(Seq(2, 3, 2), 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16)
+        result.print()
+        Tensor.assertEqual(result, expected)
+      }
+    }
+    runTest(binops)
+  }
+
+  testGPU("binary-ops-broadcast2") {
+    val binops = new LanternDriverCublas[String, Unit] {
+      override val fileName = "lantern-gpu-binops-broadcast2"
+
+      @virtualize
+      def snippet(x: Rep[String]): Rep[Unit] = {
+        val x = Tensor.fromData(Seq(2, 1, 4), 1, 2, 3, 4, 5, 6, 7, 8)
+        val y = Tensor.fromData(Seq(1, 3, 1), 1, 2, 3)
+        val result = (x + y).toCPU()
+
+        backend = BackendCPU()
+        val expected = Tensor.fromData(Seq(2, 3, 4),
+          2, 3, 4, 5,
+          3, 4, 5, 6,
+          4, 5, 6, 7,
+          6, 7, 8, 9,
+          7, 8, 9, 10,
+          8, 9, 10, 11)
         result.print()
         Tensor.assertEqual(result, expected)
       }


### PR DESCRIPTION
TODO:
- Generalize `launchBinaryKernel` function. Create a wrapper
  `launchKernel` function and reuse it for other use cases
  (tensor-scalar ops, unary ops).
- Implement in-place versions of ops (e.g. `+=`).