### PR TITLE
Implement cuDNN `conv2D_batch`.

### DIFF
--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -2812,8 +2812,7 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
       BackendCPU().makeTensor(dims, scalars: _*).toGPU()
     }
 
-    // Reference:
-    // https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot
+    // Reference: https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-dot
     // NOTE: `sdot` fails when the cuBLAS pointer mode is host (as opposed to device).
     // Investigate performance impact.
     def sdot(n: Int, a: Rep[Array[Float]], b: Rep[Array[Float]], result: Rep[Array[Float]]) = {
@@ -2828,8 +2827,7 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
       Tensor(res, 1)
     }
 
-    // Reference:
-    // https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemv
+    // Reference: https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemv
     def sgemv(m: Int, n: Int, matrix: Rep[Array[Float]], vector: Rep[Array[Float]], result: Rep[Array[Float]]) = {
       val zero = NewArray[Float](1); zero(0) = 0
       val one = NewArray[Float](1); one(0) = 1
@@ -2847,8 +2845,7 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
       Tensor(res, m)
     }
 
-    // Reference:
-    // https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemm
+    // Reference: https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemm
     def sgemm(m: Int, n: Int, k: Int, a: Rep[Array[Float]], b: Rep[Array[Float]], result: Rep[Array[Float]]) = {
       val zero = NewArray[Float](1); zero(0) = 0
       val one = NewArray[Float](1); one(0) = 1
@@ -3015,6 +3012,7 @@ trait TensorDslCudnn extends TensorDslCublas {
       generateRawCode("CUDNN_CALL(cudnnDestroy(cudnnHandle));")
     }
 
+    // Reference: https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html#cudnnConvolutionForward
     def cudnnConvolutionForward(input: Tensor, filter: Tensor, res: Tensor, bias: Option[Tensor] = None,
                                 padding: (Int, Int), strides: (Int, Int), dilations: (Int, Int)): Unit = {
       val zero = NewArray[Float](1); zero(0) = 0

--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -3095,7 +3095,7 @@ trait TensorDslCudnn extends TensorDslCublas {
       val resHeight = convSize(input.shape(3) + padUp + padDown, kernel.shape(3), strideCol)
       val resShape = Seq(input.shape(0), kernel.shape(0), resWidth, resHeight)
       val res = bias match {
-        case Some(bias) => fillWithBias(Seq(input.shape(0), kernel.shape(0), resWidth, resHeight), bias, 1)
+        case Some(bias) => fillWithBias(resShape, bias, 1)
         case None => Tensor(mallocArray[Float](resShape.product), resShape: _*)
       }
       cudnnConvolutionForward(input, kernel, res, padding = (padUp, padLeft), strides = (strideCol, strideRow), dilations = (1, 1))

--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -186,7 +186,10 @@ trait TensorDsl extends DslOps with Diff {
     def mallocArray[T: Manifest](length: Int): Rep[Array[T]]
 
     // Initialize a tensor with the specified dimensions and repeated value.
-    def makeRepeatingTensor(dims: Seq[Int], value: Rep[Float]): Tensor
+    def fill(dims: Seq[Int], value: Rep[Float]): Tensor
+
+    // Initialize a tensor with the specified bias tensor at the specified dimension.
+    def fillWithBias(dims: Seq[Int], bias: Tensor, dim: Int): Tensor
 
     // Initialize a tensor with the specified dimensions and scalar values.
     def makeTensor(dims: Seq[Int], scalars: Float*): Tensor
@@ -270,11 +273,33 @@ trait TensorDsl extends DslOps with Diff {
     override def cleanup() {}
     override def mallocArray[T: Manifest](length: Int): Rep[Array[T]] = NewArray[T](length)
 
-    override def makeRepeatingTensor(dims: Seq[Int], value: Rep[Float]): Tensor = {
+    override def fill(dims: Seq[Int], value: Rep[Float]): Tensor = {
       val scalarCount = dims.product
       val array = mallocArray[Float](scalarCount)
       for (i <- (0 until scalarCount): Rep[Range]) array(i) = value
       Tensor(array, dims: _*)
+    }
+
+    override def fillWithBias(dims: Seq[Int], bias: Tensor, dim: Int): Tensor = {
+      assert(dim >= 0 && dim < dims.size, s"Target dimension $dim is out of range $dims")
+      assert(bias.rank == 1 && bias.scalarCount == dims(dim),
+        "Bias must be 1D and have length equal to the target dimension")
+      val scalarCount = dims.product
+      val res = mallocArray[Float](scalarCount)
+
+      // iterate for higherDims
+      val offset = var_new(0)
+      for (hd <- DataLoop(dims.take(dim).product)) {
+        // iterate for current dim
+        for (cd <- DataLoop(dims.drop(dim).head)) {
+          // iterate for lowerDims
+          for (ld <- DataLoop(dims.drop(dim+1).product)) {
+            res(offset) = bias.data(cd)
+            offset += 1
+          }
+        }
+      }
+      Tensor(res, dims: _*)
     }
 
     override def makeTensor(dims: Seq[Int], scalars: Float*): Tensor = {
@@ -1659,7 +1684,7 @@ trait TensorDsl extends DslOps with Diff {
       new Tensor(res, dims)
     }
 
-    def fill(dims: Seq[Int], value: Rep[Float]): Tensor = backend.makeRepeatingTensor(dims, value)
+    def fill(dims: Seq[Int], value: Rep[Float]): Tensor = backend.fill(dims, value)
 
     def fill(dims: Seq[Int], fFill: Seq[Rep[Int]] => Rep[Float]) = {
       val scalarCount = dims.product
@@ -1683,26 +1708,7 @@ trait TensorDsl extends DslOps with Diff {
       new Tensor(res, dims)
     }
 
-    def fillWithBias(dims: Seq[Int], bias: Tensor, dim: Int) = {
-      assert(dim < dims.size && dim >= 0, s"target dimension ${dim} is out of range ${dims}")
-      assert(bias.rank == 1 && bias.scalarCount == dims.drop(dim).head, s"bias should be 1D and have the same length as given dim")
-      val scalarCount = dims.product
-      val res = backend.mallocArray[Float](scalarCount)
-
-      // iterate for higherDims
-      val offset = var_new(0)
-      for (hd <- DataLoop(dims.take(dim).product)) {
-        // iterate for current dim
-        for (cd <- DataLoop(dims.drop(dim).head)) {
-          // iterate for lowerDims
-          for (ld <- DataLoop(dims.drop(dim+1).product)) {
-            res(offset) = bias.data(cd)
-            offset += 1
-          }
-        }
-      }
-      new Tensor(res, dims)
-    }
+    def fillWithBias(dims: Seq[Int], bias: Tensor, dim: Int) = backend.fillWithBias(dims, bias, dim)
 
     def scalar(value: Rep[Float]) = {
       val res = backend.mallocArray[Float](1)
@@ -2794,8 +2800,12 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
 
     override def mallocArray[T: Manifest](length: Int): Rep[Array[T]] = NewGPUArray[T](length)
 
-    override def makeRepeatingTensor(dims: Seq[Int], value: Rep[Float]): Tensor = {
-      BackendCPU().makeRepeatingTensor(dims, value).toGPU()
+    override def fill(dims: Seq[Int], value: Rep[Float]): Tensor = {
+      BackendCPU().fill(dims, value).toGPU()
+    }
+
+    override def fillWithBias(dims: Seq[Int], bias: Tensor, dim: Int): Tensor = {
+      BackendCPU().fillWithBias(dims, bias.toCPU(), dim).toGPU()
     }
 
     override def makeTensor(dims: Seq[Int], scalars: Float*): Tensor = {
@@ -3086,9 +3096,10 @@ trait TensorDslCudnn extends TensorDslCublas {
       val resWidth = convSize(input.shape(2) + padLeft + padRight, kernel.shape(2), strideRow)
       val resHeight = convSize(input.shape(3) + padUp + padDown, kernel.shape(3), strideCol)
       val resShape = Seq(input.shape(0), kernel.shape(0), resWidth, resHeight)
-      val resData = mallocArray[Float](resShape.product)
-      // TODO: Implement convolution with bias.
-      val res = Tensor(resData, resShape: _*)
+      val res = bias match {
+        case Some(bias) => fillWithBias(Seq(input.shape(0), kernel.shape(0), resWidth, resHeight), bias, 1)
+        case None => Tensor(mallocArray[Float](resShape.product), resShape: _*)
+      }
       cudnnConvolutionForward(input, kernel, res, padding = (padUp, padLeft), strides = (strideCol, strideRow), dilations = (1, 1))
       res
     }

--- a/src/test/scala/lantern/TestCublas.scala
+++ b/src/test/scala/lantern/TestCublas.scala
@@ -6,7 +6,7 @@ import org.scala_lang.virtualized.SourceContext
 class TestCublas extends LanternFunSuite {
   testGPU("vector-vector-dot") {
     val vvdot = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-vvdot"
+      override val fileName = "lantern-cublas-vvdot"
 
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
@@ -24,7 +24,7 @@ class TestCublas extends LanternFunSuite {
 
   testGPU("matrix-vector-dot") {
     val mvdot = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-mvdot"
+      override val fileName = "lantern-cublas-mvdot"
 
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
@@ -43,7 +43,7 @@ class TestCublas extends LanternFunSuite {
 
   testGPU("matrix-matrix-dot") {
     val mmdot = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-mmdot"
+      override val fileName = "lantern-cublas-mmdot"
 
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
@@ -62,7 +62,7 @@ class TestCublas extends LanternFunSuite {
 
   testGPU("binary-ops") {
     val binops = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-binops"
+      override val fileName = "lantern-cublas-binops"
 
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
@@ -83,7 +83,7 @@ class TestCublas extends LanternFunSuite {
 
   testGPU("binary-ops-broadcast1") {
     val binops = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-binops-broadcast1"
+      override val fileName = "lantern-cublas-binops-broadcast1"
 
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
@@ -108,7 +108,7 @@ class TestCublas extends LanternFunSuite {
 
   testGPU("binary-ops-broadcast2") {
     val binops = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-binops-broadcast2"
+      override val fileName = "lantern-cublas-binops-broadcast2"
 
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {
@@ -131,7 +131,7 @@ class TestCublas extends LanternFunSuite {
 
   testGPU("binary-ops-tensor-scalar") {
     val binops = new LanternDriverCublas[String, Unit] {
-      override val fileName = "lantern-gpu-binops-tensor-scalar"
+      override val fileName = "lantern-cublas-binops-tensor-scalar"
 
       @virtualize
       def snippet(x: Rep[String]): Rep[Unit] = {

--- a/src/test/scala/lantern/TestCudnn.scala
+++ b/src/test/scala/lantern/TestCudnn.scala
@@ -80,4 +80,26 @@ class TestCudnn extends LanternFunSuite {
     }
     runTest(conv2D)
   }
+
+  testGPU("conv2D-bias") {
+    val conv2D = new LanternDriverCudnn[String, Unit] {
+      override val fileName = "lantern-cudnn-conv2d-bias"
+
+      @virtualize
+      def snippet(a: Rep[String]): Rep[Unit] = {
+        val input = Tensor.ones(1, 3, 8, 8)
+        val kernel = Tensor.ones(1, 3, 3, 3)
+        val bias = Tensor.ones(1)
+        val strides = Seq(2, 2)
+        val pads = Seq(0,0,0,0)
+        val result = input.conv2D_batch(kernel, Some(bias), strides, pads).toCPU()
+
+        backend = BackendCPU()
+        val expected = Tensor.fill(Seq(1,1,3,3), 28.0f)
+        result.print()
+        Tensor.assertEqual(expected, result)
+      }
+    }
+    runTest(conv2D)
+  }
 }


### PR DESCRIPTION
- Move CPU implementation of `conv2D_batch` and related helpers to
  `BackendCPU`.
- Implement cuDNN `conv2D_batch` using `cudnnConvolutionForward`.
- Make `fillWithBias` backend-defined, implement cuDNN `conv2D_batch` with bias.

TODO:
- Implement cudNN conv2D gradient using `cudnnConvolutionBackward`.
- Consider merging `conv2D` and `conv2D_batch` functions. Also consider merging `conv`, `convBP` and `convBBP` defined on `TensorR`.