### PR TITLE
Implement cuDNN activation functions.

### DIFF
--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -281,7 +281,7 @@ trait TensorDsl extends DslOps with Diff {
     def conv2D_batch_grad(input: TensorR, finput: Option[TensorR], filter: TensorR, res: TensorR, bias: Option[TensorR] = None,
                           padding: (Int, Int), strides: (Int, Int), dilations: (Int, Int)): Unit
 
-    // Activation function.
+    // Activation functions.
     def relu(x: Tensor): Tensor
     def tanh(x: Tensor): Tensor
     def sigmoid(x: Tensor): Tensor
@@ -296,7 +296,6 @@ trait TensorDsl extends DslOps with Diff {
     //   - Roll out own reduction op kernels? There may be significant boilerplate.
     //   - Use thrust library reduction ops? Need to consider device_vector initialization overhead.
     // - Pooling, dropout.
-    // - Activation functions (e.g. relu).
     // - Fused multiply add operations?
   }
 

--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -735,7 +735,7 @@ trait TensorDsl extends DslOps with Diff {
 
     override def sigmoid(x: Tensor) = x.map(s => 1.0f / (Math.exp(-1.0f * s).toFloat + 1.0f))
     override def sigmoid_grad(input: TensorR, res: TensorR): Unit = {
-      input.d.add_oneMinusSquare_mult(res.x, res.d)
+      input.d.add_oneMinusThenMult_mult(res.x, res.d)
     }
   }
 

--- a/src/test/scala/lantern/LanternFunSuite.scala
+++ b/src/test/scala/lantern/LanternFunSuite.scala
@@ -24,7 +24,6 @@ class LanternFunSuite extends FunSuite {
   // - The existence of a GPU (perhaps run `nvidia-smi`).
   def isGPUAvailable: Boolean = sys.env.get("LANTERN_RUN_GPU").isDefined
 
-
   // Utility function wrapping `test` that checks whether GPU is available.
   def testGPU(testName: String, testTags: Tag*)(testFun: => Any /* Assertion */)(implicit pos: source.Position) {
     if (isGPUAvailable)

--- a/src/test/scala/lantern/TestCudnn.scala
+++ b/src/test/scala/lantern/TestCudnn.scala
@@ -115,11 +115,11 @@ class TestCudnn extends LanternFunSuite {
         val strides = Seq(1,1)
         val pads = Seq(0,0,0,0)
 
-        def loss(x: TensorR) = {
+        def conv(x: TensorR) = {
           input.convBBP(kernel, Some(bias), strides, pads)
         }
-        gradR(loss)(Tensor.zeros(1))
-        gradR(loss)(Tensor.zeros(1))
+        gradR(conv)(Tensor.zeros(1))
+        gradR(conv)(Tensor.zeros(1))
 
         backend = BackendCPU()
         val expect_input_grad = Tensor.fromData(Seq(1,1,4,4),


### PR DESCRIPTION
- Add wrapper functions for `cudnnActivationForward` and
  `cudnnActivationBackward`.
- Implement relu/tanh/sigmoid (original and gradient functions) using cuDNN, add tests.

TODO:
- Support activations for non-4D tensors. This will likely require shape
  padding with "1" dimensions to work with the cuDNN API.