### PR TITLE
Temporary bandaid for `sum` on GPU.

### DIFF
--- a/src/main/scala/lantern/NIPS18App/MnistCNN.scala
+++ b/src/main/scala/lantern/NIPS18App/MnistCNN.scala
@@ -78,7 +78,8 @@ object MnistCNN {
 
         train.foreachBatch(batch) { (batchIndex: Rep[Int], input: Tensor, target: Rep[Array[Int]]) =>
           imgIdx += batch
-          val inputR = TensorR(input, isInput=true)
+          // val inputR = TensorR(input, isInput=true)
+          val inputR = TensorR(input.toGPU(), isInput=true)
           val loss = gradR_loss(lossFun(inputR, target))(Tensor.scalar(0.0f))
           trainLoss += loss.data(0)
           opt.step()


### PR DESCRIPTION
- Let GPU `sum` forward the CPU implementation for now.
  - It's clearly suboptimal for `nllLoss` and `sum` to transfer between
    CPU/GPU, but defining the ops in this way is good for getting things
    to work.
  - I would argue that it's important to encapsulate transfer logic
    within ops, to prevent transfer-related bugs. Future GPU
    implementations of `nllLoss` and `sum` can then be drop-in
    replacements.

The next blocker for MNIST CNN model is GPU elementwise op backpropagation
logic, which isn't implemented.