### PR TITLE
Fix GPU out-of-memory errors.

### DIFF
--- a/src/main/scala/lantern/DslAPI.scala
+++ b/src/main/scala/lantern/DslAPI.scala
@@ -456,7 +456,11 @@ trait DslGenCublas extends DslGenBase with CudaGenGPUOps {
       |}
       |
       |void *gpuMallocAddr;
+      |
+      |// Alignment boundary size, in bytes.
+      |constexpr int N = 4; // 16
       |void *myGpuMalloc(size_t bytes) {
+      |  bytes = ((bytes + (1 << N) - 1) >> N) << N;
       |  void *res = gpuMallocAddr;
       |  gpuMallocAddr = (void *)((char *)gpuMallocAddr + bytes);
       |  return res;

--- a/src/main/scala/lantern/DslAPI.scala
+++ b/src/main/scala/lantern/DslAPI.scala
@@ -455,6 +455,7 @@ trait DslGenCublas extends DslGenBase with CudaGenGPUOps {
       |  } \
       |}
       |
+      |void *gpuMallocBase;
       |void *gpuMallocAddr;
       |
       |// Alignment boundary size, in bytes.

--- a/src/main/scala/lantern/NIPS18App/MnistCNN.scala
+++ b/src/main/scala/lantern/NIPS18App/MnistCNN.scala
@@ -17,13 +17,9 @@ import java.io.PrintWriter;
 import java.io.File;
 
 object MnistCNN {
-
-  val root_dir = "src/out/NIPS18evaluation/"
-  // val file_dir = "evaluationCNN/Lantern/Lantern.cpp"
-  val file_dir = "evaluationCNN/Lantern/Lantern.cu"
-
-  // val mnist = new LanternDriverC[String, Unit] {
-  val mnist = new LanternDriverCudnn[String, Unit] {
+  val mnistCPU = new LanternDriverC[String, Unit] {
+    override val dir = "src/out/NIPS18evaluation"
+    override val fileName = "evaluationCNN/Lantern/Lantern.cpp"
 
     @virtualize
     def snippet(a: Rep[String]): Rep[Unit] = {
@@ -50,12 +46,103 @@ object MnistCNN {
       val opt = SGD(net, learning_rate = 0.005f, gradClip = 1000.0f)
 
       def lossFun(input: TensorR, target: Rep[Array[Int]]) = { (batchIndex: TensorR) =>
-        val res = net(input).logSoftmaxB()//.nllLossB(target)
-        res.nllLossB(target)
+        net(input).logSoftmaxB().nllLossB(target).sum()
       }
 
       // Training
-      val nbEpoch = 4
+      val nbEpoch = 100
+
+      val tot1 = NewArray[Long](2)
+      val tot2 = NewArray[Long](2)
+
+      val train = new Dataset.DataLoader("mnist", true, mean = 0.1307f, std = 0.3081f, Seq(iChan1, iRow1, iCol1))
+      train.normalize()
+
+      val prepareTime = dataTimer.getElapsedTime / 1e6f
+      printf("Data normalized (all prepare time) in %lf sec\\n", prepareTime)
+
+      val loss_save = NewArray[Double](nbEpoch)
+
+      val addr = getMallocAddr() // remember current allocation pointer here
+
+      generateRawComment("training loop starts here")
+      for (epoch <- 0 until nbEpoch: Rep[Range]) {
+        val trainTimer = Timer2()
+        var imgIdx = var_new(0)
+        var trainLoss = var_new(0.0f)
+        printf("Start training epoch %d\\n", epoch + 1)
+        trainTimer.startTimer
+
+        train.foreachBatch(batch) { (batchIndex: Rep[Int], input: Tensor, target: Rep[Array[Int]]) =>
+          imgIdx += batch
+          val inputR = TensorR(input, isInput=true)
+          val loss = gradR_loss(lossFun(inputR, target))(Tensor.zeros(4))
+          trainLoss += loss.data(0)
+          opt.step()
+
+          // selective printing
+          if (imgIdx % (train.length / 10) == 0) {
+            printf(s"Train epoch %d: [%d/%d (%.0f%%)]\\tAverage Loss: %.6f\\n", epoch, imgIdx, train.length, 100.0 * imgIdx /train.length, trainLoss/imgIdx)
+            unchecked[Unit]("fflush(stdout)")
+          }
+          resetMallocAddr(addr)
+        }
+        val delta = trainTimer.getElapsedTime
+        printf("Training completed in %ldms (%ld us/images)\\n", delta/1000L, delta/train.length)
+
+        loss_save(epoch) = trainLoss / train.length
+      }
+
+      val totalTime = dataTimer.getElapsedTime / 1e6f
+      val loopTime = totalTime - prepareTime
+      val timePerEpoc = loopTime / nbEpoch
+
+      val fp2 = openf(a, "w")
+      fprintf(fp2, "unit: %s\\n", "1 epoch")
+      for (i <- (0 until loss_save.length): Rep[Range]) {
+        fprintf(fp2, "%lf\\n", loss_save(i))
+      }
+      fprintf(fp2, "run time: %lf %lf\\n", prepareTime, timePerEpoc)
+      closef(fp2)
+    }
+  }
+
+  // TODO: Unify CPU/GPU model code.
+  val mnistGPU = new LanternDriverCudnn[String, Unit] {
+    override val dir = "src/out/NIPS18evaluation"
+    override val fileName = "evaluationCNN/Lantern/Lantern.cu"
+
+    @virtualize
+    def snippet(a: Rep[String]): Rep[Unit] = {
+      Random.srand(Some(42))
+      val dataTimer = Timer2()
+      dataTimer.startTimer
+
+      val (batch, iChan1, iRow1, iCol1) = (100, 1, 28, 28)
+
+      case class MNIST(val name: String = "mnist") extends Module {
+        val conv1 = Conv2D(inChannel = 1, outChannel = 10, kernelSize = Seq(5, 5))
+        val conv2 = Conv2D(inChannel = 10, outChannel = 20, kernelSize = Seq(5, 5))
+        val linear1 = Linear1D(inSize = 320, outSize = 50)
+        val linear2 = Linear1D(inSize = 50, outSize = 10)
+
+        def apply(in: TensorR): TensorR @diff = {
+          val step1 = conv1(in).relu().maxPoolBK(kernels = Seq(2,2), strides = Seq(2,2), None)
+          val step2 = conv2(step1).relu().maxPoolBK(kernels = Seq(2,2), strides = Seq(2,2), None)
+          val step3 = linear1(step2.resize(-1, 320)).dropout(0.5f)
+          linear2(step3)
+        }
+      }
+      val net = MNIST()
+      val opt = SGD(net, learning_rate = 0.005f, gradClip = 1000.0f)
+
+      def lossFun(input: TensorR, target: Rep[Array[Int]]) = { (batchIndex: TensorR) =>
+        // TODO: decouple `sum` operation from `nllLossB`.
+        net(input).logSoftmaxB().nllLossB(target)
+      }
+
+      // Training
+      val nbEpoch = 100
 
       val tot1 = NewArray[Long](2)
       val tot2 = NewArray[Long](2)
@@ -115,8 +202,11 @@ object MnistCNN {
   }
 
   def main(args: Array[String]) {
-    val cnn_file = new PrintWriter(new File(root_dir + file_dir))
-    cnn_file.println(mnist.code)
-    cnn_file.flush()
+    // Set `mnist` to either `mnistCPU` or `mnistGPU`.
+    val mnist = mnistCPU
+    val fileName = s"${mnist.dir}/${mnist.fileName}"
+    val cnnFile = new PrintWriter(fileName)
+    cnnFile.println(mnist.code)
+    cnnFile.flush()
   }
 }

--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -3223,8 +3223,7 @@ trait TensorDslCudnn extends TensorDslCublas {
           |size_t ws_size;
           |CUDNN_CALL(cudnnGetConvolutionForwardWorkspaceSize(
           |    cudnnHandle, in_desc, filt_desc, conv_desc, out_desc, algo, &ws_size));
-          |float *ws_data;
-          |CUDA_CALL(cudaMalloc(&ws_data, ws_size));
+          |void *ws_data = myGpuMalloc(ws_size);
           |""".stripMargin) ++
         Seq(
           "// Execute convolution.\n" +
@@ -3326,8 +3325,7 @@ trait TensorDslCudnn extends TensorDslCublas {
           |size_t ws_size;
           |CUDNN_CALL(cudnnGetConvolutionBackwardDataWorkspaceSize(
           |    cudnnHandle, filt_desc, grad_out_desc, conv_desc, grad_in_desc, algo, &ws_size));
-          |float *ws_data;
-          |CUDA_CALL(cudaMalloc(&ws_data, ws_size));
+          |void *ws_data = myGpuMalloc(ws_size);
           |""".stripMargin) ++
         Seq(
           "CUDNN_CALL(cudnnConvolutionBackwardData(\n" +
@@ -3383,8 +3381,7 @@ trait TensorDslCudnn extends TensorDslCublas {
           |size_t ws_size;
           |CUDNN_CALL(cudnnGetConvolutionBackwardFilterWorkspaceSize(
           |    cudnnHandle, in_desc, grad_out_desc, conv_desc, grad_filt_desc, algo, &ws_size));
-          |float *ws_data;
-          |CUDA_CALL(cudaMalloc(&ws_data, ws_size));
+          |void *ws_data = myGpuMalloc(ws_size);
           |""".stripMargin) ++
         Seq(
           "CUDNN_CALL(cudnnConvolutionBackwardFilter(\n" +
@@ -3557,13 +3554,13 @@ trait TensorDslCudnn extends TensorDslCublas {
           |CUDNN_CALL(cudnnDropoutGetStatesSize(
           |    cudnnHandle, &stateSizeInBytes
           |));
-          |void* state; CUDA_CALL(cudaMalloc(&state, stateSizeInBytes));
+          |void* state = myGpuMalloc(stateSizeInBytes);
           |
           |size_t sizeInBytes;
           |CUDNN_CALL(cudnnDropoutGetReserveSpaceSize(
           |    in_desc, &sizeInBytes
           |));
-          |void* reserveSpace; CUDA_CALL(cudaMalloc(&reserveSpace, sizeInBytes));
+          |void* reserveSpace = myGpuMalloc(sizeInBytes);
           |
           |""".stripMargin,
           reserveSpace, " = (float*)reserveSpace;\n",
@@ -3599,13 +3596,13 @@ trait TensorDslCudnn extends TensorDslCublas {
           |CUDNN_CALL(cudnnDropoutGetStatesSize(
           |    cudnnHandle, &stateSizeInBytes
           |));
-          |void* state; CUDA_CALL(cudaMalloc(&state, stateSizeInBytes));
+          |void* state = myGpuMalloc(stateSizeInBytes);
           |
           |size_t sizeInBytes;
           |CUDNN_CALL(cudnnDropoutGetReserveSpaceSize(
           |    in_desc, &sizeInBytes
           |));
-          |void* reserveSpace; CUDA_CALL(cudaMalloc(&reserveSpace, sizeInBytes));
+          |void* reserveSpace = myGpuMalloc(sizeInBytes);
           |
           |cudnnDropoutDescriptor_t dropoutDesc;
           |CUDNN_CALL(cudnnCreateDropoutDescriptor(&dropoutDesc));
@@ -3854,8 +3851,7 @@ trait TensorDslCudnn extends TensorDslCublas {
           |size_t ws_size;
           |CUDNN_CALL(cudnnGetReductionWorkspaceSize(
           |    cudnnHandle, reduce_desc, x_desc, out_desc, &ws_size));
-          |float *ws_data;
-          |CUDA_CALL(cudaMalloc(&ws_data, ws_size));
+          |void *ws_data = myGpuMalloc(ws_size);
           |""".stripMargin) ++
         Seq(
           "CUDNN_CALL(cudnnReduceTensor(\n" +

--- a/src/main/scala/lantern/TensorDifferentiation.scala
+++ b/src/main/scala/lantern/TensorDifferentiation.scala
@@ -2784,13 +2784,14 @@ trait TensorDslCublas extends TensorDsl with GPUOps {
     override def setup(): Unit = generateRawCode(
       """cublasHandle_t cublasHandle;
         |CUBLAS_CALL(cublasCreate(&cublasHandle));
-        |CUDA_CALL(cudaMalloc(&gpuMallocAddr, HEAP_SIZE));
-        |CUDA_CALL(cudaMemset(gpuMallocAddr, 0, HEAP_SIZE));
+        |CUDA_CALL(cudaMalloc(&gpuMallocBase, HEAP_SIZE));
+        |CUDA_CALL(cudaMemset(gpuMallocBase, 0, HEAP_SIZE));
+        |gpuMallocAddr = gpuMallocBase;
       """.stripMargin)
 
     override def cleanup(): Unit = generateRawCode(
       """CUBLAS_CALL(cublasDestroy(cublasHandle));
-        |CUDA_CALL(cudaFree(gpuMallocAddr));
+        |CUDA_CALL(cudaFree(gpuMallocBase));
       """.stripMargin)
 
     override def mallocArray[T: Manifest](length: Int): Rep[Array[T]] = NewGPUArray[T](length)


### PR DESCRIPTION
This PR is a WIP, please don't merge yet. I created it so others can see progress and leave feedback.

---

Implement GPU memory arena, with a boundary separating persistent memory (i.e. input and parameters) and non-persistent memory (i.e. intermediate results in training loop).

- [x] Eliminate all direct calls to `cudaMalloc`, use `myGpuMalloc` instead.
- [x] Fix GPU memory alignment issues.
  - Verified that alignment is fixed. Without [this patch](https://github.com/feiwang3311/Lantern/pull/38/commits/b1317013d5d8b9713351fb9ec3b841ae470c40bd), I get the error `CUDA error occurred: misaligned address`. Thanks to @GSAir for the alignment implementation.
  - We may need more fine-grained alignment control (coalescing/warp details), which may lead to speed ups. We can inspect/mimic the alignment of `cudaMalloc`.
- [ ] Implement memory boundary and freeing operations.
  - The goal is to enable allocation and freeing of persistent and non-persistent memory. Specifically, in models, the input and parameters should be persistent and not freed until the end of the program. Results of computation in the training loop should be non-persistent and freed at the end of each batch/epoch iteration.
  - *Brainstorming implementation details*
    - Mimic CPU memory watermark implementation. This leads to CPU/GPU implementation parity.
    - ~~It will likely be necessary to add a "persistence" flag to `NewGPUArray`. This enables interleaving of persistent/non-persistent allocation. Otherwise, it seems all persistent memory must be allocated before non-persistent memory to enforce the boundary, which is unreasonable.~~