### PR TITLE
Implement GPU nllLoss and array transfer ops.

### DIFF
--- a/src/main/scala/common/GPUOps.scala
+++ b/src/main/scala/common/GPUOps.scala
@@ -8,14 +8,23 @@ trait GPUOps extends ArrayOps {
     // Allocate an array of the specified size on the GPU.
     def apply[T: Manifest](scalarCount: Rep[Int]): Rep[Array[T]] = gpu_array_new(scalarCount)
   }
+  object GPUArray {
+    def apply[T: Manifest](xs: Rep[T]*) = gpu_array_fromseq(xs)
+  }
   def gpu_array_new[T: Manifest](scalarCount: Rep[Int]): Rep[Array[T]]
+  def gpu_array_fromseq[T: Manifest](xs: Seq[Rep[T]]): Rep[Array[T]]
 }
 
 trait GPUOpsExp extends ArrayOpsExp {
   case class GPUArrayNew[T: Manifest](scalarCount: Rep[Int]) extends Def[Array[T]] {
     val m = manifest[T]
   }
+  case class GPUArrayFromSeq[T: Manifest](xs: Seq[Exp[T]]) extends Def[Array[T]] {
+    val m = manifest[T]
+    val mArray = manifest[Array[T]]
+  }
   def gpu_array_new[T: Manifest](scalarCount: Exp[Int]) = reflectMutable(GPUArrayNew(scalarCount))
+  def gpu_array_fromseq[T: Manifest](xs: Seq[Rep[T]]): Rep[Array[T]] = /*reflectMutable(*/ GPUArrayFromSeq(xs) /*)*/
 }
 
 trait CudaGenGPUOps extends CGenBase {
@@ -24,11 +33,19 @@ trait CudaGenGPUOps extends CGenBase {
 
   // Allocate GPU memory.
   def getCudaMallocString(buffer: String, count: String, dataType: String): String =
-    "CUDA_CALL(cudaMalloc((void **)&" + buffer + ", " + count + " * sizeof(" + dataType + ")));"
+    "CUDA_CALL(cudaMalloc((void **)&" + buffer + ", " + count + " * sizeof(" + dataType + ")))"
 
   // Allocate GPU memory from memory arena.
   def getCudaMallocArenaString(count: String, dataType: String): String =
-    "(" + dataType + "*)myGpuMalloc(" + count + " * sizeof(" + dataType + "));"
+    "(" + dataType + "*)myGpuMalloc(" + count + " * sizeof(" + dataType + "))"
+
+  // Copy an array from host to device.
+  def cudaMemcpyHostToDevice(dest: String, src: String, count: String, dataType: String): String =
+    s"CUDA_CALL(cudaMemcpy($dest, $src, $count * sizeof($dataType), cudaMemcpyHostToDevice))"
+
+  // Copy an array from device to host.
+  def cudaMemcpyDeviceToHost(dest: String, src: String, count: String, dataType: String): String =
+    s"CUDA_CALL(cudaMemcpy($dest, $src, $count * sizeof($dataType), cudaMemcpyDeviceToHost))"
 
   // Allocate unified memory, accessible by CPU and GPU.
   // FIXME: I encountered "bus error" when performing CPU ops on managed memory:
@@ -43,6 +60,16 @@ trait CudaGenGPUOps extends CGenBase {
     case a@GPUArrayNew(n) =>
       val dataType = remap(a.m)
       emitValDef(sym, getCudaMallocArenaString(quote(n), dataType))
+    case a@GPUArrayFromSeq(xs) =>
+      val dataType = remap(a.m)
+      val count = xs.length.toString
+      // Allocate GPU array.
+      emitValDef(sym, getCudaMallocArenaString(count, dataType))
+      // Initialize CPU array.
+      val src = fresh(a.mArray)
+      emitNode(src, ArrayFromSeq(xs)(a.m))
+      // Copy CPU array to GPU array.
+      stream.println(cudaMemcpyHostToDevice(quote(sym), quote(src), count, dataType))
     case _ => super.emitNode(sym,rhs)
   }
 }

--- a/src/main/scala/lantern/NIPS18App/MnistCNN.scala
+++ b/src/main/scala/lantern/NIPS18App/MnistCNN.scala
@@ -30,7 +30,7 @@ object MnistCNN {
       val dataTimer = Timer2()
       dataTimer.startTimer
 
-      val (batch, iChan1, iRow1, iCol1) = (100, 1, 28, 28)
+      val (batchSize, iChan1, iRow1, iCol1) = (100, 1, 28, 28)
 
       case class MNIST(val name: String = "mnist") extends Module {
         val conv1 = Conv2D(inChannel = 1, outChannel = 10, kernelSize = Seq(5, 5))
@@ -78,8 +78,8 @@ object MnistCNN {
         printf("Start training epoch %d\\n", epoch + 1)
         trainTimer.startTimer
 
-        train.foreachBatch(batch) { (batchIndex: Rep[Int], input: Tensor, target: Rep[Array[Int]]) =>
-          imgIdx += batch
+        train.foreachBatch(batchSize) { (batchIndex: Rep[Int], input: Tensor, target: Rep[Array[Int]]) =>
+          imgIdx += batchSize
           val inputR = TensorR(input, isInput=true)
           val loss = gradR_loss(lossFun(inputR, target))(Tensor.zeros(4))
           trainLoss += loss.data(0)
@@ -121,7 +121,7 @@ object MnistCNN {
       val dataTimer = Timer2()
       dataTimer.startTimer
 
-      val (batch, iChan1, iRow1, iCol1) = (100, 1, 28, 28)
+      val (batchSize, iChan1, iRow1, iCol1) = (100, 1, 28, 28)
 
       case class MNIST(val name: String = "mnist") extends Module {
         val conv1 = Conv2D(inChannel = 1, outChannel = 10, kernelSize = Seq(5, 5))
@@ -152,6 +152,7 @@ object MnistCNN {
       val tot2 = NewArray[Long](2)
 
       val train = new Dataset.DataLoader("mnist", true, mean = 0.1307f, std = 0.3081f, Seq(iChan1, iRow1, iCol1))
+      train.target.moveToGPU(train.tlen)
       train.normalize()
 
       val prepareTime = dataTimer.getElapsedTime / 1e6f
@@ -170,8 +171,8 @@ object MnistCNN {
         printf("Start training epoch %d\\n", epoch + 1)
         trainTimer.startTimer
 
-        train.foreachBatch(batch) { (batchIndex: Rep[Int], input: Tensor, target: Rep[Array[Int]]) =>
-          imgIdx += batch
+        train.foreachBatch(batchSize) { (batchIndex: Rep[Int], input: Tensor, target: Rep[Array[Int]]) =>
+          imgIdx += batchSize
           val inputR = TensorR(input.toGPU(), isInput=true)
           val loss = gradR_loss(lossFun(inputR, target))(Tensor.zeros(4))
           trainLoss += loss.data(0)

--- a/src/main/scala/lantern/NIPS18App/MnistCNN.scala
+++ b/src/main/scala/lantern/NIPS18App/MnistCNN.scala
@@ -142,7 +142,7 @@ object MnistCNN {
 
       def lossFun(input: TensorR, target: Rep[Array[Int]]) = { (batchIndex: TensorR) =>
         val res = net(input).logSoftmaxB().nllLossB(target)
-        res
+        res.sum()
       }
 
       // Training
@@ -152,6 +152,7 @@ object MnistCNN {
       val tot2 = NewArray[Long](2)
 
       val train = new Dataset.DataLoader("mnist", true, mean = 0.1307f, std = 0.3081f, Seq(iChan1, iRow1, iCol1))
+      // Move target labels to GPU.
       train.target.moveToGPU(train.tlen)
       train.normalize()
 

--- a/src/out/NIPS18evaluation/evaluationCNN/Lantern/Lantern.cpp
+++ b/src/out/NIPS18evaluation/evaluationCNN/Lantern/Lantern.cpp
@@ -724,7 +724,7 @@ float* x644 = (float*)myMalloc(1 * sizeof(float));;
 x644[0] = x643;
 float* x646 = (float*)myMalloc(1 * sizeof(float));;
 x646[0] = 1.0f;
-// backend is lantern.TensorDsl$BackendCPU@52571d55
+// backend is lantern.TensorDsl$BackendCPU@3dc4e842
 float x649 = x644[0];
 x127[0] = x649;
 // 'sum' gradient.

--- a/src/test/scala/lantern/TestCudnn.scala
+++ b/src/test/scala/lantern/TestCudnn.scala
@@ -320,7 +320,7 @@ class TestCudnn extends LanternFunSuite {
       @virtualize
       def snippet(a: Rep[String]): Rep[Unit] = {
         val input = Tensor.fromData(Seq(2, 3), 1, 2, 3, 4, 5, 6)
-        val target: Rep[Array[Int]] = Array(1, 0)
+        val target: Rep[Array[Int]] = GPUArray[Int](1, 0)
         val result = input.logSoftmaxB().nllLossB(target)
         val grad = gradR(x => x.logSoftmaxB().nllLossB(target))(input)
 


### PR DESCRIPTION
- Implement `nllLoss` and `nllLoss_grad` kernels.
- Add `GPUArrayFromSeq` expression.
  - This is necessary for initializing the "target" argument of type
    `Array[Int]` on GPU.
- Add array transfer expressions.
  - Array transfer ops are necessary for transferring non-`Tensor` arrays,
    e.g. target labels of type `Rep[Array[Int]]`.
  - Redefine tensor transfer ops in terms of array copy ops.

GPU `nllLoss` and `nllLoss_grad` behave as expected (verified in `lantern-cudnn-nll-loss`).
MNIST CNN works using GPU `nllLoss`.