### PR TITLE
Add explicit sbt version.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.6


### PR DESCRIPTION
[CI currently fails](https://travis-ci.org/feiwang3311/Lantern/builds/448699167) because it implicitly uses sbt version 0.13.17, which doesn't support `Global / concurrentRestrictions`.

A simple solution is to fix the sbt version. I'm creating a PR instead of committing directly in case anyone objects to version 1.2.6.