### PR TITLE
Implement cuDNN CTC loss.

### DIFF
--- a/src/test/scala/lantern/TestCudnn.scala
+++ b/src/test/scala/lantern/TestCudnn.scala
@@ -681,4 +681,29 @@ class TestCudnn extends LanternFunSuite {
     }
     runTest(lstmModule)
   }
+
+  testGPU("ctc-loss") {
+    val ctcLoss = new LanternDriverCudnn[String, Unit] {
+      override val fileName = "lantern-cudnn-ctc-loss"
+      @virtualize
+      def snippet(a: Rep[String]): Rep[Unit] = {
+        val inputLength = 50
+        val batchSize = 16
+        val alphabetSize = 20
+
+        // val logProbs = Tensor.ones(inputLength, batchSize, alphabetSize)
+        // Note: `probs` should be the result of `logProbs.softmax(dim = 2)`.
+        val probs = Tensor.fill(Seq(inputLength, batchSize, alphabetSize), 0.05f)
+        val target = Array(Seq.fill(batchSize)(1).map(unit(_)): _*)
+        val inputLengths = Array(Seq.fill(batchSize)(inputLength).map(unit(_)): _*)
+        val targetLengths = Array(Seq.fill(batchSize)(1).map(unit(_)): _*)
+
+        val (loss, _) = BackendCudnn().cudnnCTCLoss(probs, target, inputLengths, targetLengths)
+
+        backend = BackendCPU()
+        loss.toCPU().print()
+      }
+    }
+    runTest(ctcLoss)
+  }
 }


### PR DESCRIPTION
- Add `cuDNNCTCLoss` wrapper function.
- Add test. Verified same result as PyTorch.

Notes:
- PyTorch's CTC loss function takes a log prob. tensor and performs softmax.
  We should edit softmax to support tensors of other dimensions.
  (We can easily support tensors with rank <= 4).
- PyTorch's CTC loss function performs a reduction op at the end to produce
  a scalar value. We can simply chain the reduction op at the end for
  simplicity.